### PR TITLE
Use a local timer and cleanup threads

### DIFF
--- a/src/main/java/org/vaadin/erik/SlideTab.java
+++ b/src/main/java/org/vaadin/erik/SlideTab.java
@@ -410,15 +410,20 @@ public class SlideTab extends PolymerTemplate<SlideTab.SlideTabModel> implements
 
         @Override
         public void run() {
-            getUI().ifPresent(ui -> ui.access(command));
-            cleanup.run();
+            try {
+                getUI().ifPresent(ui -> ui.access(command));
+            } finally {
+                cleanup.run();
+            }
         }
 
         @Override
         public boolean cancel() {
-            boolean result = super.cancel();
-            cleanup.run();
-            return result;
+            try {
+                return super.cancel();
+            } finally {
+                cleanup.run();
+            }
         }
 
     }


### PR DESCRIPTION
For every instance of SlideTab a Timer was created, even if no schedule function is used in the callers code.
To make it worse the Timer thread is never stopped, resulting in thread leaks.

This PR starts a Timer instance only when needed. Afterwards the timer is cleaned up properly.

It would be nice to get a 3.0.2 because many people still use Vaadin LTE.